### PR TITLE
Ignore lambda package since it is in the same repository as the test …

### DIFF
--- a/test-suite/glide.lock
+++ b/test-suite/glide.lock
@@ -1,5 +1,5 @@
-hash: bd75ec0b49c31e40d732d4bc627bf4c4b78187dab306f804c1b6806b6cb58324
-updated: 2016-03-09T15:57:52.11531567+05:30
+hash: 3acc61a3ed582a0bed9b45f7ca21745e319397b3685a57d2b33ee6cf32870eaf
+updated: 2016-03-10T15:41:06.138951394+05:30
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 2e7cf03d7f5c8a4b4c9f7341ddf1e13102845cf2
@@ -25,18 +25,6 @@ imports:
   - aws/ec2metadata
   - private/protocol/json/jsonutil
   - private/protocol/rest
-- name: github.com/fsouza/go-dockerclient
-  version: 9b6c9720043b74304a6dd07a2a901d16e7bf3d3d
-  subpackages:
-  - external/github.com/docker/docker/opts
-  - external/github.com/docker/docker/pkg/archive
-  - external/github.com/docker/docker/pkg/fileutils
-  - external/github.com/docker/docker/pkg/homedir
-  - external/github.com/docker/docker/pkg/stdcopy
-  - external/github.com/hashicorp/go-cleanhttp
-  - external/github.com/Sirupsen/logrus
-  - external/github.com/opencontainers/runc/libcontainer/user
-  - external/golang.org/x/sys/unix
 - name: github.com/go-ini/ini
   version: 776aa739ce9373377cd16f526cdf06cb4c89b40f
 - name: github.com/iron-io/iron_go3
@@ -46,10 +34,9 @@ imports:
   - api
   - config
 - name: github.com/iron-io/lambda
-  version: 87d7e8b826b6f14fa15fb639e8f448fcfba9e7d0
+  version: ""
   subpackages:
   - lambda
-  - test-suite/util
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/satori/go.uuid

--- a/test-suite/glide.yaml
+++ b/test-suite/glide.yaml
@@ -1,4 +1,6 @@
 package: github.com/iron-io/lambda/test-suite
+ignore:
+- github.com/iron-io/lambda
 import:
 - package: github.com/aws/aws-sdk-go
   version: ~1.1.9
@@ -12,9 +14,6 @@ import:
 - package: github.com/iron-io/iron_go3
   subpackages:
   - worker
-- package: github.com/iron-io/lambda
-  subpackages:
-  - lambda
 - package: github.com/satori/go.uuid
 - package: github.com/sendgrid/sendgrid-go
   version: ~2.0.0


### PR DESCRIPTION
…suite.

This needs glide 0.9.3 which was released yesterday.
