### PR TITLE
Allow non-object events and add node/python tests for it.

### DIFF
--- a/images/node/bootstrap.js
+++ b/images/node/bootstrap.js
@@ -227,7 +227,7 @@ function run() {
   var path = process.env["PAYLOAD_FILE"];
   if (path) {
     try {
-      var contents = fs.readFileSync(path);
+      var contents = fs.readFileSync(path, { encoding: 'utf8' });
       payload = JSON.parse(contents);
     } catch(e) {
       console.error("bootstrap: Error reading payload file", e)

--- a/test-suite/tests/node/test-event-integer/lambda.test
+++ b/test-suite/tests/node/test-event-integer/lambda.test
@@ -1,0 +1,7 @@
+{
+  "handler": "test.run",
+  "runtime": "nodejs",
+  "name": "event-integer",
+  "description": "Test non-JSON object payload.",
+  "event": 4294967296
+}

--- a/test-suite/tests/node/test-event-integer/test.js
+++ b/test-suite/tests/node/test-event-integer/test.js
@@ -1,0 +1,4 @@
+exports.run = function(event, context) {
+  console.log(event);
+  context.succeed();
+}

--- a/test-suite/tests/python/test-event-integer/lambda.test
+++ b/test-suite/tests/python/test-event-integer/lambda.test
@@ -1,0 +1,8 @@
+{
+  "handler": "test.run",
+  "runtime": "python2.7",
+  "name": "event-integer",
+  "description": "Integer payload",
+  "event" : 4294967296,
+  "timeout" : 5
+}

--- a/test-suite/tests/python/test-event-integer/test.py
+++ b/test-suite/tests/python/test-event-integer/test.py
@@ -1,0 +1,4 @@
+from __future__ import print_function
+
+def run(event, context):
+    print( "%d" % (event))

--- a/test-suite/util/util.go
+++ b/test-suite/util/util.go
@@ -11,13 +11,11 @@ import (
 	iron_lambda "github.com/iron-io/lambda/lambda"
 )
 
-type Payload map[string]interface{}
-
 type TestDescription struct {
 	Handler     string
 	Name        string
 	Runtime     string
-	Event       Payload
+	Event       interface{}
 	Description string // Completely ignored by test harness, just useful to convey intent of test.
 
 	// The test's timeout in seconds, valid timeout as imposed by Lambda


### PR DESCRIPTION
Allowed by Lambda, also needed for Java tests.

@vlopatkin 
