### PR TITLE
Run tests on internal cluster.

### DIFF
--- a/test-suite/iron.go
+++ b/test-suite/iron.go
@@ -97,6 +97,7 @@ func runOnIron(w *worker.Worker, wg *sync.WaitGroup, test *util.TestDescription,
 	timeout := time.Duration(test.Timeout) * time.Second
 
 	taskids, err := w.TaskQueue(worker.Task{
+		Cluster:  "internal",
 		CodeName: fmt.Sprintf("%s/%s", imagePrefix, test.Name),
 		Payload:  string(payload),
 		Timeout:  &timeout,


### PR DESCRIPTION
As discussed at https://iron.slack.com/archives/dev/p1457704111001215 to possibly avoid aufs errors.

@vlopatkin 
