### PR TITLE
Default to empty string when getting TASK_TIMEOUT.

### DIFF
--- a/images/python/bootstrap.py
+++ b/images/python/bootstrap.py
@@ -113,7 +113,7 @@ def getPAYLOAD_FILE():
 
 def getTASK_TIMEOUT():
     try:
-        return int(os.environ.get('TASK_TIMEOUT'))
+        return int(os.environ.get('TASK_TIMEOUT', ''))
     except ValueError:
         return 3600
 


### PR DESCRIPTION
The ValueError will catch it and use the default timeout.

@treeder @vlopatkin @BupycHuk could one of you look at this?