### PR TITLE
Redirect stdout for python, java and nodejs

### DIFF
--- a/examples/s3/example.js
+++ b/examples/s3/example.js
@@ -59,10 +59,10 @@ exports.run = function(event, context) {
             ACL: 'public-read',
           }, function (err, data) {
             if (err) throw err;
-            context.done()
+            context.succeed("Image updated");
           });
         } else {
-          context.done();
+          context.succeed("Image not updated");
         }
       });
     });

--- a/images/java/src/main/java/io/iron/lambda/Launcher.java
+++ b/images/java/src/main/java/io/iron/lambda/Launcher.java
@@ -12,6 +12,14 @@ import com.google.gson.JsonSyntaxException;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 
 public class Launcher {
+
+    PrintStream oldout;
+
+    public Launcher() {
+        oldout =  System.out;
+        System.setOut(System.err);
+    }
+
     public static void main(String[] args) {
         String handler = args[0];
         String payload = "";
@@ -134,10 +142,10 @@ public class Launcher {
 
         try {
             String jsonInString = ClassTypeHelper.gson.toJson(result);
-            System.out.println(jsonInString);
+            oldout.println(jsonInString);
         }
         catch (Exception e) {
-            System.out.println("{\"error\": \"" + ClassTypeHelper.gson.toJson(e.toString()) + "\"}");
+            oldout.println("{\"error\": \"" + ClassTypeHelper.gson.toJson(e.toString()) + "\"}");
             System.exit(1);
          }
     }

--- a/images/node/bootstrap.js
+++ b/images/node/bootstrap.js
@@ -2,6 +2,9 @@
 
 var fs = require('fs');
 
+var oldlog = console.log
+console.log = console.error
+
 // Some notes on the semantics of the succeed(), fail() and done() methods.
 // Tests are the source of truth!
 // First call wins in terms of deciding the result of the function. BUT,
@@ -67,7 +70,7 @@ var Context = function() {
     var failed = false;
     try {
       // Output result to log
-      console.log(JSON.stringify(result));
+      oldlog(JSON.stringify(result));
     } catch(e) {
       // Set X-Amz-Function-Error: Unhandled header
       console.log("Unable to stringify body as json: " + e);
@@ -107,10 +110,10 @@ var Context = function() {
       } else {
         errstr = error.toString()
       }
-      console.log(JSON.stringify({"errorMessage": errstr }))
+      oldlog(JSON.stringify({"errorMessage": errstr }))
     } catch(e) {
       // Set X-Amz-Function-Error: Unhandled header
-      console.log(errstr)
+      oldlog(errstr)
     }
   }
 
@@ -284,7 +287,7 @@ function run() {
         var mod = require('./'+script);
         var func = mod[entry];
         if (func === undefined) {
-          console.log("Handler '" + entry + "' missing on module '" + script + "'");
+          oldlog("Handler '" + entry + "' missing on module '" + script + "'");
           return;
         }
 
@@ -295,12 +298,12 @@ function run() {
         mod[entry](payload, makeCtx())
       } catch(e) {
         if (typeof e === 'string') {
-          console.log(e)
+          oldlog(e)
         } else {
-          console.log(e.message)
+          oldlog(e.message)
         }
         if (!started) {
-          console.log("Process exited before completing request\n")
+          oldlog("Process exited before completing request\n")
         }
       }
     } else {

--- a/images/python/bootstrap.py
+++ b/images/python/bootstrap.py
@@ -8,6 +8,8 @@ import logging.config
 import time
 import uuid
 
+oldstdout = sys.stdout
+sys.stdout = sys.stderr
 
 debugging = False
 
@@ -274,7 +276,7 @@ debugging and print ('handler found')
 
 try:
     result = caller.call(payload, context)
-    sys.stdout.write(json.dumps(result))
+    oldstdout.write(json.dumps(result))
 except Exception as e:
     stopWithError(e)
 


### PR DESCRIPTION
For each one of these runtimes, any print to stdout must not contaminate the response sent back to the callers. Currently, println and console.logs would pollute the response correctly rendered by lambda code.

This commit fixes the issue by redirecting all output that would have gone to stdout to be sent to stderr. And, keeping a lone pointer to stdout which is then used to print lambda result.

This fixes the problem for IronFunctions. Code review should reveal whether it creates a regression for IronWorker.